### PR TITLE
Update openapi.yaml to include usage stats endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,8 +4,10 @@ info:
   title: Digital Reception
   version: 1.0.0
 servers:
-- url: https://api.dreception.com
-  description: Reseller API
+- url: "https://api-demo.dreception.com"
+  description: "Reseller Demo API"
+- url: "https://api.dreception.com"
+  description: "Reseller API"
 paths:
   "/v1/r/list_api_keys":
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -380,3 +380,43 @@ paths:
                     type: boolean
               example:
                 result: false
+  "/v1/r/usage_stats":
+    get:
+      summary: usage_stats
+      tags:
+      - Reseller
+      parameters:
+      - name: key
+        in: query
+        schema:
+          type: string
+        example: zR7rsYew0Q_yLMk2jLgOvAthAf5n5q11TSYrRjO7aNjQ
+      responses:
+        '200':
+          description: Returns a list of usage stats for the system
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: integer
+              example:
+                name: "Events in last 7 days"
+                value: 20
+                name: "Events in last 24 hours"
+                value: 5
+                name: "Visitor care notes in last 30 days"
+                value: 15
+                name: "Resident care notes in last 30 days"
+                value: 5
+                name: "Total number of people"
+                value: 100
+                name: "Locations used in last 30 days"
+                value: 2
+                name: "People used in last 30 days"
+                value: 30


### PR DESCRIPTION
This PR also restores the demo server to the YAML file, as it appears to have been removed as an oversight.

This will bring the docs in line with [this PR](https://github.com/digital-reception/dr-api/pull/489).